### PR TITLE
add dependency and gitignore

### DIFF
--- a/index-in-files/.gitignore
+++ b/index-in-files/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index-in-files/package.json
+++ b/index-in-files/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "files": [
     "index.js"
-  ]
+  ],
+  "dependencies": {
+    "noop3": "^13.8.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node stress.js"
+    "test": "node stress.js",
+    "postinstall": "cd index-in-files && npm install"
   },
   "keywords": [],
   "author": "Forrest L Norvell <ogd@aoaioxxysz.net>",


### PR DESCRIPTION
I tested your repo and it worked. But when I add the `.gitignore` toghether with a dependency like `noop3`, it fails.

```
/Users/sam/Projects/opensource/eliminate-5082/test.js .. 18/19
  run scenarios concurrently
  not ok tar found index.js for index-in-files scenario
    +++ found
    --- wanted
    -0
    +1
    compare: ===
    at:
      line: 101
      column: 13
      file: test.js
    stack: |
      test.js:101:13
      f (node_modules/once/once.js:17:25)
      ChildProcess.<anonymous> (test.js:75:5)
      Pipe._handle.close [as _onclose] (net.js:485:12)
    source: |
      t.equal(
```

Make sure to go into the `index-in-files` directory and `npm install` the dependency.
